### PR TITLE
Standardized locale names

### DIFF
--- a/locale/cs_CZ/locale.xml
+++ b/locale/cs_CZ/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the cs_CZ (Czech) locale.
+  * Localization strings for the cs_CZ (Čeština) locale.
   -->
 
-<locale name="cs_CZ" full_name="Czech">
+<locale name="cs_CZ" full_name="Čeština">
 	<message key="plugins.generic.tinymce.name">Plugin TinyMCE</message>
 	<message key="plugins.generic.tinymce.description"><![CDATA[Tento plugin umožňuje WYSIWYG editování textových polí OMP s využitím <a href="http://tinymce.moxiecode.com" target="_blank">TinyMCE</a> editoru obsahu.]]></message>
 	<message key="plugins.generic.tinymce.settings">Nastavení</message>

--- a/locale/da_DK/locale.xml
+++ b/locale/da_DK/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Dutch) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   -->
 
-<locale name="da_DK" full_name="Dutch">
+<locale name="da_DK" full_name="Dansk">
 	<message key="plugins.generic.tinymce.name">TinyMCE Plugin</message>
 	<message key="plugins.generic.tinymce.description"><![CDATA[Dette plugin aktiverer WYSIWYG redigering af OMP tekstfelter ved hjælp af <a href="http://tinymce.moxiecode.com" target="_blank">TinyMCE</a> tekstbehandleren.]]></message>
 	<message key="plugins.generic.tinymce.settings">Indstillinger</message>

--- a/locale/el_GR/locale.xml
+++ b/locale/el_GR/locale.xml
@@ -18,7 +18,7 @@
   * Papaxristopoulos Leonidas (leonidasp@lis.upatras.gr)
   -->
 
-<locale name="el_GR" full_name="Greek">
+<locale name="el_GR" full_name="ελληνικά">
 	<message key="plugins.generic.tinymce.name">TinyMCE Plugin</message>
 	<message key="plugins.generic.tinymce.description"><![CDATA[Το plugin αυτό ενεργοποιεί την WYSIWYG επεξεργασία των πεδίων κειμένου του OMP με την χρήση του  επεξεργαστή περιεχομένου <a href="http://tinymce.moxiecode.com" target="_blank">TinyMCE</a>.]]></message>
 	<message key="plugins.generic.tinymce.settings">Ρυθμίσεις</message>

--- a/locale/fa_IR/locale.xml
+++ b/locale/fa_IR/locale.xml
@@ -7,7 +7,7 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the fa_IR (Persian) locale.
+  * Localization strings for the fa_IR (فارسی) locale.
   -->
 <locale full_name="Farsi" name="fa_IR" >
 	<message key="plugins.generic.tinymce.name" >پلاگین TinyMCE</message>

--- a/locale/fr_CA/locale.xml
+++ b/locale/fr_CA/locale.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the fr_CA (Canadian French) locale.
+  * Localization strings for the fr_CA (Français (Canada)) locale.
   -->
 
 <locale name="fr_CA" full_name="Français (Canada)">

--- a/locale/hr_HR/locale.xml
+++ b/locale/hr_HR/locale.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the hr_HR (hrvatski) locale.
+  * Localization strings for the hr_HR (Hrvatski) locale.
   *
   * Marija Matesic(mmatesi1@ffzg.hr), Tomislav Biscan (info@seofruits.com.hr) Exp $
   -->

--- a/locale/no_NO/locale.xml
+++ b/locale/no_NO/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the no_NO (Norwegian) locale.
+  * Localization strings for the no_NO (Norsk) locale.
   -->
 
-<locale name="no_NO" full_name="Norwegian">
+<locale name="no_NO" full_name="Norsk">
 	<message key="plugins.generic.tinymce.name">TinyMCE-plugin</message>
 	<message key="plugins.generic.tinymce.description"><![CDATA[Denne plugin'en oppretter WYSIWYG-redigering i OMP tekstfelt ved bruk av <a href="http://tinymce.moxiecode.com" target="_blank">TinyMCE</a>-editor.]]></message>
 	<message key="plugins.generic.tinymce.settings">Innstillinger</message>

--- a/locale/pt_BR/locale.xml
+++ b/locale/pt_BR/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings for the pt_BR locale.
   -->
 
-<locale name="pt_BR" full_name="Português do Brasil">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<message key="plugins.generic.tinymce.name">Plugin TinyMCE</message>
 	<message key="plugins.generic.tinymce.description"><![CDATA[Este plugin permite edição WYSIWYG (What You See Is What You Get) em campos de texto através do editor de conteúdo <a href="http://tinymce.moxiecode.com" target="_blank">TinyMCE</a>.]]></message>
 	<message key="plugins.generic.tinymce.settings">Configurações</message>

--- a/locale/pt_PT/locale.xml
+++ b/locale/pt_PT/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings for the pt_PT locale.
   -->
 
-<locale name="pt_PT" full_name="Português">
+<locale name="pt_PT" full_name="Português (Portugal)">
 	<message key="plugins.generic.tinymce.name">Plugin TinyMCE</message>
 	<message key="plugins.generic.tinymce.description"><![CDATA[Este plugin permite edição WYSIWYG (What You See Is What You Get) em campos de texto através do editor de conteúdo <a href="http://tinymce.moxiecode.com" target="_blank">TinyMCE</a>.]]></message>
 	<message key="plugins.generic.tinymce.settings">Configurações</message>

--- a/locale/ru_RU/locale.xml
+++ b/locale/ru_RU/locale.xml
@@ -11,7 +11,7 @@
   * Localization strings for the ru_RU locale.
   -->
 
-<locale name="ru_RU" full_name="Russian">
+<locale name="ru_RU" full_name="Русский">
 	<message key="plugins.generic.tinymce.name">Модуль TinyMCE</message>
 	<message key="plugins.generic.tinymce.description"><![CDATA[Модуль позволяет визуальное (WYSIWYG) редактирование текстовых полей в OMP с использованием редактора <a href="http://tinymce.moxiecode.com" target="_blank">TinyMCE</a>.]]></message>
 	<message key="plugins.generic.tinymce.settings">Настройки</message>

--- a/locale/tr_TR/locale.xml
+++ b/locale/tr_TR/locale.xml
@@ -8,10 +8,10 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the tr_TR (Türkiye Türkçesi) locale.
+  * Localization strings for the tr_TR (Türkçe) locale.
   -->
 
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.generic.tinymce.name">TinyMCE Eklentisi</message>
 	<message key="plugins.generic.tinymce.description"><![CDATA[Bu eklenti OMP yazı alanlarının <a href="http://tinymce.moxiecode.com" target="_blank">TinyMCE</a> içerik düzenleyici kullanılarak görüldüğü gibi yazılmasını sağlar.]]></message>
 	<message key="plugins.generic.tinymce.settings">Ayarlar</message>


### PR DESCRIPTION
Following the recent standardization of locale names in the PKP applications, this tackles the tinymce plugin.
