### PR TITLE
Harmonize de_DE locale with the ojs locale

### DIFF
--- a/locale/de_DE/locale.xml
+++ b/locale/de_DE/locale.xml
@@ -12,8 +12,8 @@
   -->
 
 <locale name="de_DE" full_name="Deutsch (Deutschland)">
-	<message key="plugins.generic.tinymce.name">TinyMCE-Plug-In</message>
-	<message key="plugins.generic.tinymce.description"><![CDATA[Dieses Plug-In aktiviert eine WSYWIG-Eingabe für Textfelder mittels des <a href="https://www.tinymce.com" target="_blank">TinyMCE</a>-Editors.]]></message>
+	<message key="plugins.generic.tinymce.name">TinyMCE-Plugin</message>
+	<message key="plugins.generic.tinymce.description"><![CDATA[Dieses Plugin aktiviert eine WSYWIG-Eingabe für Textfelder mittels des <a href="https://www.tinymce.com" target="_blank">TinyMCE</a>-Editors.]]></message>
 	<message key="plugins.generic.tinymce.settings">Einstellungen</message>
 
 	<message key="plugins.generic.tinymce.pkpTags.listTags">Tag auswählen</message>


### PR DESCRIPTION
The [main locale](https://github.com/pkp/ojs/blob/master/locale/de_DE/locale.xml) of ojs translates `plugin` as `Plugin` not as `Plug-In`.